### PR TITLE
Finished Footer Responsive

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,7 @@ const Footer = () => {
               <Link
                 target={link.target}
                 href={link.href}
-                className="flex flex-row duration-150 hover:scale-110 sm:text-3xl lg:text-5xl"
+                className="flex flex-row text-3xl duration-150 hover:scale-110 md:text-4xl lg:text-5xl"
               >
                 <link.icon />
               </Link>


### PR DESCRIPTION
![footerResponsiveFix](https://github.com/user-attachments/assets/00331268-8bce-4513-802c-26d56b601f61)
- Img is the size of icon for Iphone XR dimensions
- basically just set normal text to 3xl, md to 4xl, and kept lg to 5xl because sm didn't apply correctly

