### PR TITLE
Responsive Landing

### DIFF
--- a/src/components/Landing.tsx
+++ b/src/components/Landing.tsx
@@ -5,7 +5,7 @@ import swLogo from "@/public/swLOGO.svg";
 
 const Landing = () => {
   return (
-    <div className="mr-28 flex h-screen items-center">
+    <div className="my-32 flex items-center justify-center sm:mr-28 sm:h-screen sm:justify-start">
       <div className="size-2/3 text-center">
         <h1 className="mb-4 bg-gradient-to-b from-[#DDA82A] via-sw-white to-[#905803] bg-clip-text text-4xl font-bold text-transparent md:text-6xl">
           WELCOME TO


### PR DESCRIPTION
<img width="318" alt="Screenshot 2024-11-04 at 11 21 33 AM" src="https://github.com/user-attachments/assets/f4ca9353-8af0-481a-885a-5aee82cd97d6">

Slightly zoomed in on image to appear like on mobile. Real mobile is skewed to the left because of black bar on the right. Someone needs to fix the ugly ass "join the galaxy" to get things centered